### PR TITLE
Improve the efficiency of a couple of methods, eliminating unneeded (temporary) lists.

### DIFF
--- a/stripy-src/stripy/spherical.py
+++ b/stripy-src/stripy/spherical.py
@@ -757,15 +757,13 @@ class sTriangulation(object):
         list / array provided.
         """
 
-        segments = []
+        segments = set()
 
         for vertex in vertices:
             neighbours = self.identify_vertex_neighbours(vertex)
+            segments.update( min( tuple((vertex, n1)), tuple((n1, vertex))) for n1 in neighbours )
 
-            for n1 in neighbours:
-                segments.append( min( tuple((vertex, n1)), tuple((n1, vertex))) )
-
-        segs = np.array(list(set(segments)))
+        segs = np.array(segments)
 
         new_midpoint_lonlats = self.segment_midpoints(segments=segs)
 
@@ -1007,15 +1005,15 @@ class sTriangulation(object):
         # identify the segments
 
         simplices = self.simplices
-        segments = []
+        segments = set()
 
         for index in np.array(triangles).reshape(-1):
             tri = simplices[index]
-            segments.append( min( tuple((tri[0], tri[1])), tuple((tri[1], tri[0]))) )
-            segments.append( min( tuple((tri[1], tri[2])), tuple((tri[2], tri[1]))) )
-            segments.append( min( tuple((tri[0], tri[2])), tuple((tri[2], tri[0]))) )
+            segments.add( min( tuple((tri[0], tri[1])), tuple((tri[1], tri[0]))) )
+            segments.add( min( tuple((tri[1], tri[2])), tuple((tri[2], tri[1]))) )
+            segments.add( min( tuple((tri[0], tri[2])), tuple((tri[2], tri[0]))) )
 
-        segs = np.array(list(set(segments)))
+        segs = np.array(segments)
 
         mlons, mlats = self.segment_midpoints(segs)
 


### PR DESCRIPTION
Improve the efficiency of `segment_midpoints_by_vertices` by removing a couple of unnecessary lists and using a comprehension. Similarly, improve the efficiency of `edge_refine_triangulation_by_triangles` by removing a couple of unnecessary lists.
The following test attempts to compare the performance (without considering the memory inefficiency of the unnecessary lists):

```
import timeit
setup = 'import numpy as np'

formal_loop = """
segments = []
for vertex in xrange(20):
    neighbours = range(5)
    for n1 in neighbours:
        segments.append( min( tuple((vertex, n1)), tuple((n1, vertex))) )
segs = np.array(list(set(segments)))
"""

timeit.timeit(formal_loop, setup=setup)
Out[3]: 64.83339289999999

set_comprehension = """
segments = set()
for vertex in xrange(20):
    neighbours = range(5)
    segments.update( min( tuple((vertex, n1)), tuple((n1, vertex))) for n1 in neighbours )
segs = np.array(segments)
"""

timeit.timeit(set_comprehension, setup=setup)
Out[5]: 48.52315300000001
```