### PR TITLE
Fix an error that could occur in coordinate transformations

### DIFF
--- a/stripy-src/stripy/spherical.py
+++ b/stripy-src/stripy/spherical.py
@@ -1201,8 +1201,8 @@ def xyz2lonlat(x,y,z):
     ys = np.array(y)
     zs = np.array(z)
 
-    lons = np.arctan2(y, x)
-    lats = np.arcsin(z)
+    lons = np.arctan2(ys, xs)
+    lats = np.arcsin(zs)
 
     return lons, lats
 
@@ -1220,8 +1220,8 @@ def dxyz2dlonlat(x,y,z, dfx, dfy, dfz):
     ys = np.array(y)
     zs = np.array(z)
 
-    lons = np.arctan2(y, x)
-    lats = np.arcsin(z)
+    lons = np.arctan2(ys, xs)
+    lats = np.arcsin(zs)
 
     dfxs = np.array(dfx)
     dfys = np.array(dfy)
@@ -1230,7 +1230,7 @@ def dxyz2dlonlat(x,y,z, dfx, dfy, dfz):
     dlon = -dfxs * np.cos(lats) * np.sin(lons) + dfys * np.cos(lats) * np.cos(lons) # no z dependence
     dlat = -dfxs * np.sin(lats) * np.cos(lons) - dfys * np.sin(lats) * np.sin(lons) + dfzs * np.cos(lats)
 
-    corr = np.sqrt((1.0-z**2))
+    corr = np.sqrt((1.0-zs**2))
     valid = ~np.isclose(corr,0.0)
 
     dlon[valid] = dlon[valid] / corr[valid]


### PR DESCRIPTION
Fix a type error that could occur in the coordinate transformation functions `xyz2lonlat` and `dxyz2dlonlat`.