### PR TITLE
Fix an error in the `remove_duplicate_lonlat` function

### DIFF
--- a/stripy-src/stripy/spherical.py
+++ b/stripy-src/stripy/spherical.py
@@ -1162,14 +1162,12 @@ def remove_duplicate_lonlat(lon, lat):
     remove duplicates from an array of lon / lat points
     """
 
+    a = np.ascontiguousarray(np.vstack((lon, lat)).T)
+    unique_a = np.unique(a.view([('', a.dtype)]*a.shape[1]))
+    llunique = unique_a.view(a.dtype).reshape((unique_a.shape[0], a.shape[1]))
 
-    if not unique:
-        a = np.ascontiguousarray(np.vstack((lon, lat)).T)
-        unique_a = np.unique(a.view([('', a.dtype)]*a.shape[1]))
-        llunique = unique_a.view(a.dtype).reshape((unique_a.shape[0], a.shape[1]))
-
-        lon1 = llunique[:,0]
-        lat1 = llunique[:,1]
+    lon1 = llunique[:,0]
+    lat1 = llunique[:,1]
 
     return lon1, lat1
 


### PR DESCRIPTION
Fix an error in the `remove_duplicate_lonlat` function referencing several undefined variables.  The return results `(lon1, lat1)` were left undefined because the `unique` variable was also undefined.