### PR TITLE
Improve the performance of `lonlat2xyz` and, indirectly, six methods …

### DIFF
--- a/stripy-src/stripy/spherical.py
+++ b/stripy-src/stripy/spherical.py
@@ -1176,9 +1176,7 @@ def lonlat2xyz(lon, lat):
     lons = np.array(lon)
     lats = np.array(lat)
 
-    xs = np.cos(lats) * np.cos(lons)
-    ys = np.cos(lats) * np.sin(lons)
-    zs = np.sin(lats)
+    xs,ys,zs = _stripack.trans(lats, lons)
 
     return xs, ys, zs
 


### PR DESCRIPTION
…of `sTriangulation`. This test illustrates the difference:

```
stripack_setup='''
from stripy.spherical_meshes import icosahedral_mesh, _stripack
mesh = icosahedral_mesh(refinement_levels=4)
lons,lats = mesh.lons, mesh.lats
'''

numpy_setup='''
from stripy.spherical_meshes import icosahedral_mesh
import numpy as np
mesh = icosahedral_mesh(refinement_levels=4)
lons,lats = mesh.lons, mesh.lats
'''

numpy_notlocal ='''
x = np.cos(lats) * np.cos(lons)
y = np.cos(lats) * np.sin(lons)
z = np.sin(lats)
'''

numpy_local ='''
cos_lats = np.cos(lats)
x = cos_lats * np.cos(lons)
y = cos_lats * np.sin(lons)
z = np.sin(lats)
'''

stripack_trans = 'x,y,z = _stripack.trans(lats, lons)'

import timeit

timeit.timeit(numpy_notlocal, setup=numpy_setup)
Out[7]: 146.5056573

timeit.timeit(numpy_local, setup=numpy_setup)
Out[8]: 121.99809429999999

timeit.timeit(stripack_trans, setup=stripack_setup)
Out[9]: 65.7638417
```