### PR TITLE
Add matplotlib & imageio recommended dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There are two matching sets of `stripy` notebooks - one set for [Cartesian Trian
 Note: the Cartesian and Spherical notebooks can be obtained / installed from `stripy` itself as follows:
 
 ```bash
-   python -c 'import stripy; stripy.documentation.install_documentation(path="Notebooks")'   
+   python -c 'import stripy; stripy.documentation.install_documentation(path="Notebooks")'
 ```
 
 ### Cartesian
@@ -85,6 +85,8 @@ Also, the following packages are required:
 **Recommended Packages** for running the notebooks:
 
  - [`gdal`](https://www.gdal.org/)
+ - [`matplotlib`](https://matplotlib.org/)
+ - [`imageio`](https://imageio.github.io/)
  - [`cartopy`](https://scitools.org.uk/cartopy/docs/latest/)
  - [`pyproj`](https://github.com/pyproj4/pyproj)
  - [`lavavu`](https://github.com/OKaluza/LavaVu/)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Also, the following packages are required:
 
 **Recommended Packages** for running the notebooks:
 
+ - [`litho1pt0`](https://pypi.org/project/litho1pt0/)
  - [`gdal`](https://www.gdal.org/)
  - [`matplotlib`](https://matplotlib.org/)
  - [`imageio`](https://imageio.github.io/)


### PR DESCRIPTION
Import of `matplotlib` and `imageio` are tested on [test/test_0_imports.py](https://github.com/underworldcode/stripy/blob/master/tests/test_0_imports.py), but they weren't required as dependencies on the `README.md`.

Please feel free to perform any change you feel appropriate.