### PR TITLE
Add instructions to run the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There are two matching sets of `stripy` notebooks - one set for [Cartesian Trian
 Note: the Cartesian and Spherical notebooks can be obtained / installed from `stripy` itself as follows:
 
 ```bash
-   python -c 'import stripy; stripy.documentation.install_documentation(path="Notebooks")'   
+   python -c 'import stripy; stripy.documentation.install_documentation(path="Notebooks")'
 ```
 
 ### Cartesian
@@ -183,7 +183,13 @@ These classes share similar methods and can be easily interchanged.
 In addition, there are many helper functions provided for building meshes.
 
 A series of tests are located in the *tests* subdirectory.
+In order to perform these tests clone the repository and run `pytest`:
 
+```bash
+git checkout https://github.com/underworldcode/stripy.git
+cd stripy
+pytest -v
+```
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ These classes share similar methods and can be easily interchanged.
 In addition, there are many helper functions provided for building meshes.
 
 A series of tests are located in the *tests* subdirectory.
-In order to perform these tests clone the repository and run `pytest`:
+In order to perform these tests clone the repository and run [`pytest`](https://pypi.org/project/pytest/):
 
 ```bash
 git checkout https://github.com/underworldcode/stripy.git


### PR DESCRIPTION
I think there was some missing instructions on how to run the tests.
I quickly wrote these lines. Maybe would be nice to have instructions on how to run them in case the used installed `stripy` through the Docker image.

Feel free to make any change you want!