### PR TITLE
Fix some errors in the `identify_segments()` method

### DIFF
--- a/stripy/spherical.py
+++ b/stripy/spherical.py
@@ -737,18 +737,14 @@ F, FX, and FY are the values and partials of a linear function which minimizes Q
         array of vertices (n1,n2) where n1 < n2
         """
 
-        lst  = self.lst
-        lend = self.lend
-        lptr = self.lptr
+        segments_set = set()
 
-        segments_array = np.empty((len(lptr),2),dtype=np.int)
-        segments_array[:,0] = lst[:] - 1
-        segments_array[:,1] = lst[lptr[:]-1] - 1
+        for n0,n1,n2 in self.simplices:
+            segments_set.add( (n0,n1) )
+            segments_set.add( (n0,n2) )
+            segments_set.add( min( (n1, n2), (n2, n1) ))
 
-        valid = np.where(segments_array[:,0] < segments_array[:,1])[0]
-        segments = segments_array[valid,:]
-
-        return self._deshuffle_simplices(segments)
+        return np.array(sorted(segments_set))
 
 
     def segment_midpoints_by_vertices(self, vertices):


### PR DESCRIPTION
The errors in the `identify_segments()` method could cause the resulting array to

1. omit segments that appear in the list of simplices, and

1. contain redundant segments.

The code below illustrates these problems.
```
# -*- coding: utf-8 -*-

import numpy as np
import stripy

#------------------------------------------------------------------------------
#%% Create a spherical mesh to illustrate some problems in identifying the segments
lats = [
    0.4636476090008061 , 0.5535743588970452 , 1.0172219678978514 ,
    0.7404347884493285 , 0.8090137403684318 , 0.2800390756822185 ,
    0.2346004447388785 , 0.5302174221557974 , 0.2800390756822185 ,
    0.5302174221557974 , 0.8090137403684318 , 0.2346004447388785 ,
    0.8232353569256703 , 0.11770116609524765, 0.7843147459528687 ,
    0.14051922408044437, 0.23774564943610824, 0.547675979715428  ,
    0.7843147459528687 , 0.5018711597048692 , 0.11762020175628357,
    0.6020411987250672 , 0.6700468172524618 , 0.9612526809070125 ,
    0.6847192030022831 , 0.8788283781735899 , 0.64091415762601   ,
    0.14051922408044434, 0.4061795652117143 , 0.11762020175628357,
    0.4181400483196014 , 0.3832567629394502 , 0.14037985103742107,
    0.2599744534475359 , 0.6409141576260101 , 0.9222131851150969 ,
    0.14037985103742107, 0.2839133608684201 , 0.11770116609524764,
    0.3832567629394502 , 0.6700468172524618 , 0.2599744534475359 ,
    0.4181400483196014 , 0.4061795652117143 , 0.547675979715428  ,
    0.3502307444387523 , 0.9612526809070125 , 0.9222131851150969 ,
    0.35023074443875235, 0.684719203002283  , 0.5018711597048692
  ]

lons = [
    1.2566370614359172, 1.884955592153876 , 1.2566370614359172,
    1.2566370614359172, 1.6473495667799687, 2.054816296212886 ,
    1.4225429272585135, 2.2072654926019135, 1.7150948880948662,
    1.5626456917058384, 2.1225616175277837, 2.3473682570492382,
    1.8849555921538763, 1.3384354156043816, 2.3245622529340517,
    1.8017164139167623, 1.2566370614359172, 2.0472535133219347,
    1.4453489313737   , 1.4068566759206225, 1.4977008800378124,
    1.2566370614359172, 1.6002907368736157, 1.7406570308539067,
    1.991330662078862 , 1.2566370614359172, 1.4216357952578687,
    1.9681947703909901, 2.126922433648507 , 2.2722103042699393,
    1.7948376624584343, 1.4883923187647126, 1.6415098999888764,
    1.567937929102895 , 2.348275389049883 , 2.291156931383537 ,
    2.1284012843188758, 1.884955592153876 , 2.43147576870337  ,
    2.281518865543039 , 2.169620447434137 , 2.201973255204857 ,
    1.975073521849318 , 1.6429887506592453, 1.7226576709858177,
    2.4268396477572423, 2.029254153453846 , 1.478754252924215 ,
    1.3430715365505093, 1.7785805222288904, 2.3630545083871293
  ]

test_mesh = stripy.sTriangulation(lons=lons, lats=lats)

#------------------------------------------------------------------------------
#%% Define two alternative functions for identifying the segments. Here, these
#   serve as candidates to replace the sTriangulation.identify_segments() method

# The identify_segments_from_simplices() function probably serves as the
# reference standard, in that it should give a complete, reliable, and
# non redundant set of segments
def identify_segments_from_simplices(self):
    """Find all the segments in the triangulation by looping over its simplices
    and return an array of vertices (n1,n2) where n1 < n2
    """
    segments_set = set()
    for n0,n1,n2 in self.simplices:
        segments_set.add( (n0,n1) )
        segments_set.add( (n0,n2) )
        segments_set.add( min( (n1, n2), (n2, n1) ))
    return np.array(sorted(segments_set))

# The identify_segments_corrected() function applies a correction to the
# sTriangulation.identify_segments() method.  It accounts for those boundary
# nodes that are represented in sTriangulation.lst by the negative of their indices.
def identify_segments_corrected(self):
    """
    Find all the segments in the triangulation, accounting for some of the
    boundary nodes represented by the negative of their indices, and return an
    array of vertices (n1,n2) where n1 < n2
    """

    lst  = self.lst
    lptr = self.lptr

    segments_array = np.empty((len(lptr),2),dtype=np.int)
    segments_array[:,0] = np.abs(lst[:]) - 1
    segments_array[:,1] = np.abs(lst[lptr[:]-1]) - 1

    valid = np.where(segments_array[:,0] < segments_array[:,1])[0]
    segments = segments_array[valid,:]

    return self._deshuffle_simplices(segments)


#------------------------------------------------------------------------------
#%% Create lists of segments using the three candidate methods.
segments_from_existing_method = test_mesh.identify_segments()
segments_from_simplices       = identify_segments_from_simplices(test_mesh)
segments_corrected            = identify_segments_corrected(test_mesh)


#------------------------------------------------------------------------------
#%% Using segments_from_simplices as the reference standard, look for
#   deficiencies in the lists of segments from the other two candidate methods.
segments_from_existing_method_set = set(tuple(s) for s in segments_from_existing_method)

print('The following segments from the list of simplices do not appear in the list from test_mesh.identify_segments():')
for idx,seg in enumerate(segments_from_simplices):
    if tuple(seg) not in segments_from_existing_method_set:
        print('    segment #{:3d}, {}'.format(idx,seg))

print('The list from test_mesh.identify_segments() has the following redundant segments:')
for idx,seg in enumerate(segments_from_existing_method):
    if (seg[0], seg[1]) in segments_from_existing_method_set and (seg[1], seg[0]) in segments_from_existing_method_set:
        print('    segment #{:3d}, {}'.format(idx,seg))


segments_corrected_set = set(tuple(s) for s in segments_corrected)

print('\nThe following segments from the list of simplices do not appear in the list from identify_segments_corrected(test_mesh):')
for idx,seg in enumerate(segments_from_simplices):
    if (tuple(seg) not in segments_corrected_set) and ((seg[1],seg[0]) not in segments_corrected_set):
        print('    segment #{:3d}, {}'.format(idx,seg))

print('The list from identify_segments_corrected(test_mesh) has the following redundant segments:')
for idx,seg in enumerate(segments_corrected):
    if (seg[0], seg[1]) in segments_corrected_set and (seg[1], seg[0]) in segments_corrected_set:
        print('    segment #{:3d}, {}'.format(idx,seg))
```
This gives the following output:
```
The following segments from the list of simplices do not appear in the list from test_mesh.identify_segments():
    segment #  0, [0 2]
    segment #  4, [ 0 21]
    segment # 14, [ 2 21]
    segment # 17, [ 2 35]
    segment # 35, [ 6 13]
    segment # 36, [ 6 16]
    segment # 65, [11 29]
    segment # 66, [11 38]
    segment # 74, [13 16]
    segment # 79, [14 45]
    segment # 80, [15 20]
    segment #129, [35 45]
The list from test_mesh.identify_segments() has the following redundant segments:
    segment # 39, [20 33]
    segment # 41, [33 20]
    segment # 59, [36 29]
    segment # 86, [29 36]

The following segments from the list of simplices do not appear in the list from identify_segments_corrected(test_mesh):
    segment #  4, [ 0 21]
    segment # 17, [ 2 35]
    segment # 74, [13 16]
    segment #129, [35 45]
The list from identify_segments_corrected(test_mesh) has the following redundant segments:
```