### PR TITLE
sTriangulation.identify_vertex_neighbours(vertex) can omit a neighbouring boundary node

### DIFF
--- a/stripy/spherical.py
+++ b/stripy/spherical.py
@@ -710,7 +710,7 @@ F, FX, and FY are the values and partials of a linear function which minimizes Q
 
         while True:
             lp = self.lptr[lp-1]
-            neighbours.append(self.lst[lp-1]-1)
+            neighbours.append(np.abs(self.lst[lp-1])-1)
             if (lp == lpl):
                 break
 


### PR DESCRIPTION
An error in the `sTriangulation.identify_vertex_neighbours(vertex)` method could cause it to omit a neighbouring boundary node.

In the `stripack` documentation/comment for `subroutine trmesh`, the section on the `LIST` output argument mentions that

> In order to distinguish between interior and boundary nodes, the last neighbor of each boundary node is represented by the negative of its index.

It might suffice to account for the possibly negated indices using the `np.abs()`, as follows
```
    def identify_vertex_neighbours(self, vertex):
        """
        Find the neighbour-vertices in the triangulation for the given vertex
        (from the data structures of the triangulation)
        """
        vertex = self._permutation[vertex]

        lpl = self.lend[vertex-1]
        lp = lpl

        neighbours = []

        while True:
            lp = self.lptr[lp-1]
            neighbours.append( np.abs(self.lst[lp-1]) -1) # <--- Allow for negated indices using np.abs()
            if (lp == lpl):
                break

        return self._deshuffle_simplices(neighbours)
```
While this change **_might_** suffice to correct the omission, note that a similar correction to the `identify_segments` method did not fix all problems there.  See the Pull request to fix `identify_segments`. Some test code that I inserted there shows that merely wrapping with `np.abs(lst[...])` fixed most problems there but left some un-addressed.
