### PR TITLE
Can't run parallel conda builds

### DIFF
--- a/.github/workflows/python_conda_build_test.yml
+++ b/.github/workflows/python_conda_build_test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         os: [ 'macos-latest', 'ubuntu-latest' ]
         python-version: [ '2.7' , '3.7' ]


### PR DESCRIPTION
Because of login tokens that cause jobs to abort. 