### PR TITLE
Windows builds and testing on GitHub Actions

### DIFF
--- a/.github/workflows/build_deploy_pdoc.yml
+++ b/.github/workflows/build_deploy_pdoc.yml
@@ -15,12 +15,10 @@ jobs:
         with:
           python-version: '3.x'    
 
-        # This is needed because we install stripy for litho1pt0 build for documentation
       - name: Install gfortran 
         run: |
           sudo apt-get install -y gfortran
          
-        # The numpy etc are needed because we install stripy for litho1pt0 build for documentation
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build_deploy_pdoc.yml
+++ b/.github/workflows/build_deploy_pdoc.yml
@@ -2,7 +2,7 @@ name: API docs
 
 on:
   push:
-    branches: [master]
+    branches: [master, dev]
 
 jobs:
   deploy:
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install stripy
         run: |
-          pip install .
+          pip install -e .
    
       - name: Build docs with pdoc
         run: |

--- a/.github/workflows/build_deploy_pdoc.yml
+++ b/.github/workflows/build_deploy_pdoc.yml
@@ -2,7 +2,7 @@ name: API docs
 
 on:
   push:
-    branches: [master, dev]
+    branches: [master]
 
 jobs:
   deploy:

--- a/.github/workflows/python_conda_build_test.yml
+++ b/.github/workflows/python_conda_build_test.yml
@@ -3,9 +3,6 @@ name: conda + pip
 on: 
   push
 
-# This should work with windows but fails in the testing phase for 
-# reasons to do with python naming (Help !!) 
-
 jobs:
   build_and_test: 
     name: Build test (${{matrix.os}}, py ${{ matrix.python-version }})
@@ -32,7 +29,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install pip 
-          conda install -c conda-forge fortran-compiler numpy scipy
+          conda install -c conda-forge compilers numpy scipy
           conda install pytest
 
       - name: Install dependencies on MacOS
@@ -40,7 +37,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install pip 
-          conda install -c conda-forge fortran-compiler numpy scipy
+          conda install -c conda-forge compilers numpy scipy
           conda install pytest
 
           

--- a/.github/workflows/python_conda_build_test.yml
+++ b/.github/workflows/python_conda_build_test.yml
@@ -24,23 +24,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies on 'ubuntu-latest' and 'windows-latest'       
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
+      - name: Install dependencies with conda
         shell: bash -l {0}
         run: |
           conda install pip 
-          conda install -c conda-forge compilers numpy scipy cython
+          conda install -c conda-forge compilers numpy scipy 
           conda install pytest
 
-      - name: Install dependencies on MacOS
-        if: matrix.os == 'macos-latest'
-        shell: bash -l {0}
-        run: |
-          conda install pip 
-          conda install -c conda-forge compilers numpy scipy cython
-          conda install pytest
-
-          
       - name: Install (self)
         shell: bash -l {0}
         run: |

--- a/.github/workflows/python_conda_build_test.yml
+++ b/.github/workflows/python_conda_build_test.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install pip 
-          conda install -c conda-forge compilers numpy scipy
+          conda install -c conda-forge compilers numpy scipy cython
           conda install pytest
 
       - name: Install dependencies on MacOS
@@ -37,7 +37,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install pip 
-          conda install -c conda-forge compilers numpy scipy
+          conda install -c conda-forge compilers numpy scipy cython
           conda install pytest
 
           

--- a/.github/workflows/python_conda_build_test.yml
+++ b/.github/workflows/python_conda_build_test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'macos-latest', 'ubuntu-latest' ]
+        os: [ 'macos-latest', 'ubuntu-latest', 'windows-latest' ]
         python-version: [ '2.7' , '3.7' ]
       
         exclude:

--- a/.github/workflows/python_conda_build_test.yml
+++ b/.github/workflows/python_conda_build_test.yml
@@ -11,10 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'macos-latest', 'ubuntu-latest', 'windows-latest' ]
-        python-version: [ '2.7' , '3.7' ]
+        python-version: [ '2.7' , '3.7', '3.8' ]
       
         exclude:
         - os: ubuntu-latest
+          python-version: '2.7'
+        - os: macos-latest
           python-version: '2.7'
 
     steps:

--- a/.github/workflows/python_conda_build_test.yml
+++ b/.github/workflows/python_conda_build_test.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python --version 
-          pip install . --no-dependencies
+          pip install -e . 
           
       - name: Test with pytest
         shell: bash -l {0}

--- a/.github/workflows/python_conda_build_test.yml
+++ b/.github/workflows/python_conda_build_test.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install pip 
-          conda install -c conda-forge libgfortran=4.0.0 numpy scipy
+          conda install -c conda-forge fortran-compiler numpy scipy
           conda install pytest
 
           

--- a/.github/workflows/python_conda_upload.yml
+++ b/.github/workflows/python_conda_upload.yml
@@ -23,20 +23,11 @@ jobs:
         shell: bash -l {0}
         run: conda info
 
-      - name: Install dependencies on 'ubuntu-latest'       
-        if: matrix.os == 'ubuntu-latest' 
+      - name: Install dependencies via conda
         shell: bash -l {0}
         run: |
           conda update -n base -c defaults conda
-          conda install -c conda-forge compilers numpy scipy cython
-          conda install pytest
-
-      - name: Install dependencies on MacOS
-        if: matrix.os == 'macos-latest'
-        shell: bash -l {0}
-        run: |
-          conda update -n base -c defaults conda
-          conda install -c conda-forge compilers numpy scipy cython
+          conda install -c conda-forge compilers numpy scipy 
           conda install pytest
 
       - name: Reinvent the wheel / upload

--- a/.github/workflows/python_conda_upload.yml
+++ b/.github/workflows/python_conda_upload.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda update -n base -c defaults conda
-          conda install -c conda-forge fortran-compiler numpy scipy
+          conda install -c conda-forge fortran-compiler libgfortran numpy scipy cython
           conda install pytest
 
       - name: Reinvent the wheel / upload

--- a/.github/workflows/python_conda_upload.yml
+++ b/.github/workflows/python_conda_upload.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda update -n base -c defaults conda
-          conda install -c conda-forge fortran-compiler numpy scipy
+          conda install -c conda-forge compilers numpy scipy cython
           conda install pytest
 
       - name: Install dependencies on MacOS
@@ -36,7 +36,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda update -n base -c defaults conda
-          conda install -c conda-forge fortran-compiler libgfortran numpy scipy cython
+          conda install -c conda-forge compilers numpy scipy cython
           conda install pytest
 
       - name: Reinvent the wheel / upload

--- a/.github/workflows/python_conda_upload.yml
+++ b/.github/workflows/python_conda_upload.yml
@@ -1,8 +1,8 @@
 name: conda -c underworldcode 
 
-on: 
-  release:
-    types: [created, edited]
+on: [push]
+  # release:
+  #   types: [created, edited]
 
 jobs:
   catch_and_release: 
@@ -36,7 +36,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda update -n base -c defaults conda
-          conda install -c conda-forge gfortran_osx-64 libgfortran numpy scipy
+          conda install -c conda-forge fortran-compiler numpy scipy
           conda install pytest
 
       - name: Reinvent the wheel / upload

--- a/.github/workflows/python_conda_upload.yml
+++ b/.github/workflows/python_conda_upload.yml
@@ -1,8 +1,8 @@
 name: conda -c underworldcode 
 
-on: [push]
-  # release:
-  #   types: [created, edited]
+on: 
+  release:
+    types: [created, edited]
 
 jobs:
   catch_and_release: 

--- a/.github/workflows/python_pip_build_test.yml
+++ b/.github/workflows/python_pip_build_test.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         os: [ 'macos-latest', 'ubuntu-latest', 'windows-latest']
         python-version: ['2.7', '3.7', '3.8']
+        exclude:
+          - os: 'windows-latest'
+            python-version: ['2.7', '3.8']
 
     runs-on: ${{ matrix.os }}
 
@@ -35,10 +38,6 @@ jobs:
         if: matrix.os == 'macos-latest' 
         run: |
           brew cask install gfortran
-
-      # - name: Install fortran (windows)
-      #   if: matrix.os == 'windows-latest'
-      #   uses: numworks/setup-msys2@v1
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/python_pip_build_test.yml
+++ b/.github/workflows/python_pip_build_test.yml
@@ -36,11 +36,29 @@ jobs:
         run: |
           brew cask install gfortran
 
-      - name: Install fortran (windows)
-        if: matrix.os == 'windows-latest'
-        uses: numworks/setup-msys2@v1
-      
-      - name: Install dependencies
+      # - name: Install fortran (windows)
+      #   if: matrix.os == 'windows-latest'
+      #   uses: numworks/setup-msys2@v1
+      - name: Install msys2 (windows)
+        if: steps.cache-msys2.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
+        run: |
+          if ( "${{ matrix.arch }}" -eq "32" ) {
+            (New-Object net.webclient).DownloadFile("http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz","msys2.tar.xz")
+          } else {
+            (New-Object net.webclient).DownloadFile("http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz","msys2.tar.xz")
+          }
+          tar xf msys2.tar.xz -C $env:GITHUB_WORKSPACE.Replace("\", "/")
+      - run: |
+          $env:MSYSTEM = "MINGW${{ matrix.arch }}"
+          $env:MSYS2_PATH_TYPE = "strict"
+          $script = @'
+            uname -m
+            uname -a
+            echo $PATH
+          '@
+          & "$env:GITHUB_WORKSPACE\msys${{ matrix.arch }}\usr\bin\bash" -c -l $script
+
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install numpy 

--- a/.github/workflows/python_pip_build_test.yml
+++ b/.github/workflows/python_pip_build_test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'macos-latest', 'ubuntu-latest']
+        os: [ 'macos-latest', 'ubuntu-latest', 'windows-latest']
         python-version: ['2.7', '3.7', '3.8']
 
     runs-on: ${{ matrix.os }}
@@ -35,6 +35,11 @@ jobs:
         if: matrix.os == 'macos-latest' 
         run: |
           brew cask install gfortran
+
+      - name: Install gfortran (windows)
+        if: matrix.os == "windows-latest"
+        uses: numworks/setup-msys2@v1
+        run: msys2do uname -a
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/python_pip_build_test.yml
+++ b/.github/workflows/python_pip_build_test.yml
@@ -53,6 +53,7 @@ jobs:
           
       - name: Test with pytest
         run: |
+          python -c 'import stripy;'
           pip install pytest
           pytest
 

--- a/.github/workflows/python_pip_build_test.yml
+++ b/.github/workflows/python_pip_build_test.yml
@@ -39,24 +39,6 @@ jobs:
       # - name: Install fortran (windows)
       #   if: matrix.os == 'windows-latest'
       #   uses: numworks/setup-msys2@v1
-      - name: Install msys2 (windows)
-        if: steps.cache-msys2.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
-        run: |
-          if ( "${{ matrix.arch }}" -eq "32" ) {
-            (New-Object net.webclient).DownloadFile("http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz","msys2.tar.xz")
-          } else {
-            (New-Object net.webclient).DownloadFile("http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz","msys2.tar.xz")
-          }
-          tar xf msys2.tar.xz -C $env:GITHUB_WORKSPACE.Replace("\", "/")
-      - run: |
-          $env:MSYSTEM = "MINGW${{ matrix.arch }}"
-          $env:MSYS2_PATH_TYPE = "strict"
-          $script = @'
-            uname -m
-            uname -a
-            echo $PATH
-          '@
-          & "$env:GITHUB_WORKSPACE\msys${{ matrix.arch }}\usr\bin\bash" -c -l $script
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/python_pip_build_test.yml
+++ b/.github/workflows/python_pip_build_test.yml
@@ -37,7 +37,7 @@ jobs:
           brew cask install gfortran
 
       - name: Install fortran (windows)
-        if: matrix.os == "windows-latest"
+        if: matrix.os == 'windows-latest'
         uses: numworks/setup-msys2@v1
       
       - name: Install dependencies

--- a/.github/workflows/python_pip_build_test.yml
+++ b/.github/workflows/python_pip_build_test.yml
@@ -16,7 +16,9 @@ jobs:
         python-version: ['2.7', '3.7', '3.8']
         exclude:
           - os: 'windows-latest'
-            python-version: ['2.7', '3.8']
+            python-version: 2.7
+          - os: 'windows-latest'
+            python-version: 3.8
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/python_pip_build_test.yml
+++ b/.github/workflows/python_pip_build_test.yml
@@ -36,10 +36,9 @@ jobs:
         run: |
           brew cask install gfortran
 
-      - name: Install gfortran (windows)
+      - name: Install fortran (windows)
         if: matrix.os == "windows-latest"
         uses: numworks/setup-msys2@v1
-        run: msys2do uname -a
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/python_pypi_upload_macos_wheel.yml
+++ b/.github/workflows/python_pypi_upload_macos_wheel.yml
@@ -1,8 +1,8 @@
 name: PYPI wheels macos
 
-on:
-  release:
-    types: [created, edited]
+on: [push]
+  # release:
+  #   types: [created, edited]
 
 
 jobs:
@@ -25,13 +25,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install gfortran (ubuntu)
-      if: matrix.os == 'ubuntu-latest' 
-      run: |
-        sudo apt-get install -y gfortran
-
     - name: Install gfortran (macos)
-      if: matrix.os == 'macos-latest' 
       run: |
         brew cask install gfortran
 
@@ -50,5 +44,5 @@ jobs:
  
       run: |
  
-        python setup.py bdist_wheel
+        python setup.py bdist_wheel 
         twine upload dist/*  --skip-existing

--- a/.github/workflows/python_pypi_upload_windows_wheel.yml
+++ b/.github/workflows/python_pypi_upload_windows_wheel.yml
@@ -1,0 +1,43 @@
+name: PYPI wheels windows
+
+on:
+  release:
+    types: [created, edited]
+
+
+jobs:
+  deploy_to_pypi:
+    name: ${{matrix.os}} build and deploy on pypi (${{ matrix.python-version }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'windows-latest']
+        python-version: ['3.6', '3.7']
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+        pip install numpy
+        pip install scipy
+        pip install Cython
+        
+    - name: Build the wheel
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+
+      run: |
+        python setup.py bdist_wheel
+        twine upload dist/*  --skip-existing

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,10 +21,12 @@ requirements:
     - pip
     - python
     - scipy >=0.15.0
+    - {{ compiler('fortran')}}
   run:
     - numpy
     - python
     - scipy >=0.15.0
+    - libgfortran
 
 
 about:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,11 +22,12 @@ requirements:
     - python
     - scipy >=0.15.0
     - {{ compiler('fortran')}}
+    
   run:
     - numpy
     - python
     - scipy >=0.15.0
-    - libgfortran
+    - {{ compiler('fortran')}}
 
 
 about:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,9 +28,6 @@ requirements:
     - numpy
     - python
     - scipy >=0.15.0
-    - {{ compiler('fortran')}}
-    - {{ compiler('c')}}
-
 
 
 about:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,12 +22,15 @@ requirements:
     - python
     - scipy >=0.15.0
     - {{ compiler('fortran')}}
+    - {{ compiler('c')}}
     
   run:
     - numpy
     - python
     - scipy >=0.15.0
     - {{ compiler('fortran')}}
+    - {{ compiler('c')}}
+
 
 
 about:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,5 @@ test=pytest
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
 
-universal=1
 [metadata]
 description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ import os
 import subprocess
 import sys 
 
-link_args = ""
+link_args = []
  
 if not "darwin" in sys.platform:
-    link_args = "-static"
+    link_args = ["-static"]
 
 # in development set version to none and ...
 PYPI_VERSION = "1.2.0"
@@ -69,16 +69,16 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 # interface for Renka's algorithm 772 fortran code
 ext1 = Extension(name    = 'stripy._stripack',
                  sources = ['src/stripack.pyf','src/stripack.f90'],
-                 extra_link_args=[link_args])
+                 extra_link_args=link_args)
 ext2 = Extension(name    = 'stripy._tripack',
                  sources = ['src/tripack.pyf', 'src/tripack.f90'],
-                 extra_link_args=[link_args])
+                 extra_link_args=link_args)
 ext3 = Extension(name    = 'stripy._srfpack',
                  sources = ['src/srfpack.pyf', 'src/srfpack.f'],
-                 extra_link_args=[link_args])
+                 extra_link_args=link_args)
 ext4 = Extension(name    = 'stripy._ssrfpack',
                  sources = ['src/ssrfpack.pyf', 'src/ssrfpack.f'],
-                 extra_link_args=[link_args])
+                 extra_link_args=link_args)
 
 if __name__ == "__main__":
     setup(name = 'stripy',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,12 @@ from os import path
 import io
 import os
 import subprocess
+import sys 
 
+link_args = ""
+ 
+if not "darwin" in sys.platform:
+    link_args = "-static"
 
 # in development set version to none and ...
 PYPI_VERSION = "1.2.0"
@@ -64,16 +69,16 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 # interface for Renka's algorithm 772 fortran code
 ext1 = Extension(name    = 'stripy._stripack',
                  sources = ['src/stripack.pyf','src/stripack.f90'],
-                 extra_link_args=["-static"])
+                 extra_link_args=[link_args])
 ext2 = Extension(name    = 'stripy._tripack',
                  sources = ['src/tripack.pyf', 'src/tripack.f90'],
-                 extra_link_args=["-static"])
+                 extra_link_args=[link_args])
 ext3 = Extension(name    = 'stripy._srfpack',
                  sources = ['src/srfpack.pyf', 'src/srfpack.f'],
-                 extra_link_args=["-static"])
+                 extra_link_args=[link_args])
 ext4 = Extension(name    = 'stripy._ssrfpack',
                  sources = ['src/ssrfpack.pyf', 'src/ssrfpack.f'],
-                 extra_link_args=["-static"])
+                 extra_link_args=[link_args])
 
 if __name__ == "__main__":
     setup(name = 'stripy',

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ from os import path
 import io
 import os
 import subprocess
-import sys 
+import platform 
 
 link_args = []
  
-if not "darwin" in sys.platform:
+if "Windows" in platform.system():
     link_args = ["-static"]
 
 # in development set version to none and ...

--- a/setup.py
+++ b/setup.py
@@ -63,13 +63,17 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 # interface for Renka's algorithm 772 fortran code
 ext1 = Extension(name    = 'stripy._stripack',
-                 sources = ['src/stripack.pyf','src/stripack.f90'])
+                 sources = ['src/stripack.pyf','src/stripack.f90'],
+                 extra_link_args=["-static"])
 ext2 = Extension(name    = 'stripy._tripack',
-                 sources = ['src/tripack.pyf', 'src/tripack.f90'])
+                 sources = ['src/tripack.pyf', 'src/tripack.f90'],
+                 extra_link_args=["-static"])
 ext3 = Extension(name    = 'stripy._srfpack',
-                 sources = ['src/srfpack.pyf', 'src/srfpack.f'])
+                 sources = ['src/srfpack.pyf', 'src/srfpack.f'],
+                 extra_link_args=["-static"])
 ext4 = Extension(name    = 'stripy._ssrfpack',
-                 sources = ['src/ssrfpack.pyf', 'src/ssrfpack.f'])
+                 sources = ['src/ssrfpack.pyf', 'src/ssrfpack.f'],
+                 extra_link_args=["-static"])
 
 if __name__ == "__main__":
     setup(name = 'stripy',

--- a/stripy/__init__.py
+++ b/stripy/__init__.py
@@ -17,15 +17,21 @@ Stripy source code is available from <https://github.com/underworldcode/stripy>
 
 """
 
-import os
-extra_dll_dir = os.path.join(os.path.dirname(__file__), 'extra-dll')
-if os.path.isdir(extra_dll_dir):
-    print(os.listdir(extra_dll_dir))
-    os.environ["PATH"] += os.pathsep + extra_dll_dir
-extra_dll_dir = os.path.join(os.path.dirname(__file__), '.libs')
-if os.path.isdir(extra_dll_dir):
-    print(os.listdir(extra_dll_dir))
-    os.environ["PATH"] += os.pathsep + extra_dll_dir
+
+import os as _os
+from platform import system as _system
+
+# add '.dll' files if we are on Windows
+if _system() == "Windows":
+    extra_dll_dir = _os.path.join(_os.path.dirname(__file__), 'extra-dll')
+    if _os.path.isdir(extra_dll_dir):
+        print(_os.listdir(extra_dll_dir))
+        _os.environ["PATH"] += _os.pathsep + extra_dll_dir
+    extra_dll_dir = _os.path.join(_os.path.dirname(__file__), '.libs')
+    if _os.path.isdir(extra_dll_dir):
+        print(_os.listdir(extra_dll_dir))
+        _os.environ["PATH"] += _os.pathsep + extra_dll_dir
+
 
 from .spherical import sTriangulation
 from .cartesian import Triangulation

--- a/stripy/__init__.py
+++ b/stripy/__init__.py
@@ -25,11 +25,9 @@ from platform import system as _system
 if _system() == "Windows":
     extra_dll_dir = _os.path.join(_os.path.dirname(__file__), 'extra-dll')
     if _os.path.isdir(extra_dll_dir):
-        print(_os.listdir(extra_dll_dir))
         _os.environ["PATH"] += _os.pathsep + extra_dll_dir
     extra_dll_dir = _os.path.join(_os.path.dirname(__file__), '.libs')
     if _os.path.isdir(extra_dll_dir):
-        print(_os.listdir(extra_dll_dir))
         _os.environ["PATH"] += _os.pathsep + extra_dll_dir
 
 

--- a/stripy/__init__.py
+++ b/stripy/__init__.py
@@ -17,6 +17,16 @@ Stripy source code is available from <https://github.com/underworldcode/stripy>
 
 """
 
+import os
+extra_dll_dir = os.path.join(os.path.dirname(__file__), 'extra-dll')
+if os.path.isdir(extra_dll_dir):
+    print(os.listdir(extra_dll_dir))
+    os.environ["PATH"] += os.pathsep + extra_dll_dir
+extra_dll_dir = os.path.join(os.path.dirname(__file__), '.libs')
+if os.path.isdir(extra_dll_dir):
+    print(os.listdir(extra_dll_dir))
+    os.environ["PATH"] += os.pathsep + extra_dll_dir
+
 from .spherical import sTriangulation
 from .cartesian import Triangulation
 from . import spherical_meshes

--- a/tests/test_1a_spherical_mesh_examples.py
+++ b/tests/test_1a_spherical_mesh_examples.py
@@ -48,30 +48,3 @@ def test_uniform_ring_mesh():
     mesh = stripy.spherical_meshes.uniform_ring_mesh(resolution=9, refinement_levels=0)
     mesh = stripy.spherical_meshes.uniform_ring_mesh(resolution=3, refinement_levels=3)
 
-
-## Cartesian meshes
-
-def test_cart_square_border():
-    mesh = stripy.cartesian_meshes.square_border((-1.0,1.0,-1.0,1.0), 0.1, 0.1, refinement_levels=0)
-    mesh = stripy.cartesian_meshes.square_border((-1.0,1.0,-1.0,1.0), 0.1, 0.1, refinement_levels=2)
-    mesh = stripy.cartesian_meshes.square_border((-1.0,1.0,-1.0,1.0), 0.1, 0.2, refinement_levels=0)
-
-
-def test_cart_square_mesh():
-    mesh = stripy.cartesian_meshes.square_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.1, refinement_levels=0)
-    mesh = stripy.cartesian_meshes.square_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.1, refinement_levels=2)
-    mesh = stripy.cartesian_meshes.square_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.2, refinement_levels=0)
-
-
-def test_elliptical_mesh():
-    mesh = stripy.cartesian_meshes.elliptical_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.1, refinement_levels=0)
-    mesh = stripy.cartesian_meshes.elliptical_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.1, refinement_levels=2)
-    mesh = stripy.cartesian_meshes.elliptical_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.2, refinement_levels=0)
-    mesh = stripy.cartesian_meshes.elliptical_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.1, random_scale=0.01, refinement_levels=0)
-    mesh = stripy.cartesian_meshes.elliptical_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.2, random_scale=0.01, refinement_levels=0)
-
-
-def test_cart_random_mesh():
-    mesh = stripy.cartesian_meshes.random_mesh((-1.0,1.0,-1.0,1.0), 5000)
-    mesh = stripy.cartesian_meshes.random_mesh((-1.0,1.0,-1.0,1.0), 10000)
-    mesh = stripy.cartesian_meshes.random_mesh((-1.0,1.0,-1.0,1.0), 20000)

--- a/tests/test_1b_cartesian_mesh_examples.py
+++ b/tests/test_1b_cartesian_mesh_examples.py
@@ -24,3 +24,15 @@ def test_elliptical_mesh():
     mesh = stripy.cartesian_meshes.elliptical_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.2, refinement_levels=0)
     mesh = stripy.cartesian_meshes.elliptical_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.1, random_scale=0.01, refinement_levels=0)
     mesh = stripy.cartesian_meshes.elliptical_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.2, random_scale=0.01, refinement_levels=0)
+
+
+def test_cart_square_mesh():
+    mesh = stripy.cartesian_meshes.square_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.1, refinement_levels=0)
+    mesh = stripy.cartesian_meshes.square_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.1, refinement_levels=2)
+    mesh = stripy.cartesian_meshes.square_mesh((-1.0,1.0,-1.0,1.0), 0.1, 0.2, refinement_levels=0)
+
+
+def test_cart_random_mesh():
+    mesh = stripy.cartesian_meshes.random_mesh((-1.0,1.0,-1.0,1.0), 5000)
+    mesh = stripy.cartesian_meshes.random_mesh((-1.0,1.0,-1.0,1.0), 10000)
+    mesh = stripy.cartesian_meshes.random_mesh((-1.0,1.0,-1.0,1.0), 20000)


### PR DESCRIPTION
Windows uses msys2 and mingw to compile fortran sources that must be manually linked on import.

https://github.com/underworldcode/stripy/blob/5e46c8550c3127a4203b2e2dcd4ca5a8a09edd6e/stripy/__init__.py#L21-L31

More details here: https://pav.iki.fi/blog/2017-10-08/pywingfortran.html#id1

Should support the following actions on Windows:

- Building and testing on python 3.7
- Building and testing with conda on python 2.7 and 3.7
- Pushing wheels to PyPI