### PR TITLE
Correct apparent errors in identify_vertex_neighbours

### DIFF
--- a/.github/workflows/build_deploy_jbdoc.yml
+++ b/.github/workflows/build_deploy_jbdoc.yml
@@ -4,7 +4,9 @@ name: API docs / jupyterbook
 
 on:
   push:
-    branches: [master]
+    branches: 
+      - master 
+      - dev
 
   workflow_run:
     workflows: ["Conda Deployment"]
@@ -38,9 +40,10 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
             miniconda-version: "latest"
+            auto-update-conda: true
             environment-file: .github/workflows/resources/conda_jb_docs_environment.yml
             activate-environment: conda-build-docs
-            python-version: 3.8
+            python-version: 3.7
             use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
   
       - name: Build docs with jupyterbook

--- a/.github/workflows/build_deploy_pdoc.yml
+++ b/.github/workflows/build_deploy_pdoc.yml
@@ -46,13 +46,8 @@ jobs:
         shell: bash -l {0}
         run: |
           VERSION=`python setup.py --version`
-          conda search stripy
           conda install -c geo-down-under stripy==$VERSION  # will explicity request this version and fail otherwise
-          # mkdir test 
-          # cd test
-          # python -c "import stripy"
 
-   
       - name: Build docs with pdoc
         shell: bash -l {0}
         run: |

--- a/.github/workflows/conda_test_build.yml
+++ b/.github/workflows/conda_test_build.yml
@@ -36,8 +36,6 @@ jobs:
           path: |
             ~/conda_pkgs_dir
             ~/.cache/pip
-            # /usr/share/miniconda3/envs/jupyter-book
-            # ~/GeodynamicsJupyterBook/GeodynamicsJupyterBook/_build
             
           key: ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('.github/workflows/resources/conda_build_environment.yml') }}
 

--- a/.github/workflows/python_pip_build_test.yml
+++ b/.github/workflows/python_pip_build_test.yml
@@ -4,7 +4,11 @@
 name: pip builds 
 
 on: 
-  push
+  push:
+    
+  pull_request:
+      
+  workflow_dispatch:
 
 jobs:
   build_with_pip:

--- a/.github/workflows/python_pypi_upload_source.yml
+++ b/.github/workflows/python_pypi_upload_source.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [created, edited]
 
+  workflow_dispatch: 
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/resources/conda_jb_docs_environment.yml
+++ b/.github/workflows/resources/conda_jb_docs_environment.yml
@@ -1,23 +1,23 @@
-# This is the environment needed to build stripy. As this will be cached, we can include any stripy dependencies
-# so they are not downloaded again - this should save a bit of time
+# This is the environment needed to run the stripy examples / build the jbook
 
 name: conda-build-docs
 channels: 
   - conda-forge
   - geo-down-under
 dependencies:
-  - stripy 
-  - litho1pt0
-  - lavavu
-  - xvfbwrapper 
-  - pdoc3
+  - geo-down-under::stripy==2.0.5b2
+  - geo-down-under::litho1pt0
+  - matplotlib
+  - pyproj
   - pyepsg
+  - h5netcdf
+  - netcdf4
   - cartopy
   - xarray
-  - numpy
-  - scipy
-  - matplotlib
-
+  - xvfbwrapper
+  - pip 
+  
   - pip:
     - jupyter-book
+    - lavavu
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 [![pip builds](https://github.com/underworldcode/stripy/workflows/pip%20builds/badge.svg)](https://github.com/underworldcode/stripy/actions?query=workflow%3A%22pip+builds%22)
 
+![Conda Deployment](https://github.com/underworldcode/stripy/workflows/Conda%20Deployment/badge.svg)
+
 
 A Python interface to TRIPACK and STRIPACK Fortran code for (constrained) triangulation in Cartesian coordinates and on a sphere. Stripy is an object-oriented package and includes routines from SRFPACK and SSRFPACK for interpolation (nearest neighbor, linear and hermite cubic) and to evaluate derivatives (Renka 1996a,b and 1997a,b).
 

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,0 +1,8 @@
+freeglut3-dev
+xvfb
+x11-utils
+libgl1-mesa-dri 
+libgl1-mesa-glx 
+
+
+

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,10 +1,25 @@
-name: stripy-binder
+# This is the environment needed to run the stripy examples in binder / thebe 
+# Note jupytext and other extensions to the server
+
+name: conda-build-docs
 channels: 
   - conda-forge
-  - geo-down-under 
-  - underworldcode
+  - geo-down-under
 dependencies:
-  - numpy
-  - scipy
-  - geo-down-under::stripy
-  - underworldcode::litho1pt0
+  - geo-down-under::stripy==2.0.5b2
+  - geo-down-under::litho1pt0
+  - matplotlib
+  - pyproj
+  - pyepsg
+  - h5netcdf
+  - netcdf4
+  - cartopy
+  - xarray
+  - xvfbwrapper  # to avoid errors 
+  - jupytext
+  - pip 
+  
+  - pip:
+    - jupyter-book
+    - lavavu
+

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -38,11 +38,6 @@ test:
     - pytest
 
 
-test:
-  imports:
-    - stripy
-
-
 
 about:
   home: "https://github.com/underworldcode/stripy"

--- a/jupyterbook/FrontPage.md
+++ b/jupyterbook/FrontPage.md
@@ -1,5 +1,15 @@
-# Introdution to Stripy
+# Introduction to Stripy
 
+
+[![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/underworldcode/stripy.svg)](https://hub.docker.com/r/underworldcode/stripy)
+[![PyPI](https://img.shields.io/pypi/v/stripy.svg)](https://pypi.org/project/stripy/)
+
+[![pip builds](https://github.com/underworldcode/stripy/workflows/pip%20builds/badge.svg)](https://github.com/underworldcode/stripy/actions?query=workflow%3A%22pip+builds%22)
+
+
+A Python interface to TRIPACK and STRIPACK Fortran code for (constrained) triangulation in Cartesian coordinates and on a sphere. Stripy is an object-oriented package and includes routines from SRFPACK and SSRFPACK for interpolation (nearest neighbor, linear and hermite cubic) and to evaluate derivatives (Renka 1996a,b and 1997a,b).
+
+`stripy` is bundled with `litho1pt0` which is a python interface to the _crust 1.0_ dataset and the lithospheric part of the _litho 1.0_ dataset (Laske et al, 2013 and Pasyanos et al, 2014) which both requires and demonstrates the triangulation / searching and interpolation on the sphere that is provided by `stripy`.
 
 
 ```{figure} https://github.com/underworldcode/stripy/blob/master/stripy/Notebooks/Images/seafloor-age-topo.png?raw=true
@@ -12,7 +22,7 @@ _Sample images created with `stripy` illustrating the meshing capability: ocean 
 
 ```
 
-
 ## Links
 
   - [Stripy on Github](https://github.com/underworldcode/stripy)
+  - [API documentation](https://underworldcode.github.io/stripy/2.0.5b2_api)

--- a/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex1-Cartesian-Triangulations.md
+++ b/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex1-Cartesian-Triangulations.md
@@ -44,7 +44,7 @@ In this notebook we introduce the `Triangulation` class itself.
    4. Renka, R. J. (1996), Algorithm 752; SRFPACK: software for scattered data fitting with a constrained surface under tension, ACM Transactions on Mathematical Software, 22(1), 9–17, doi:10.1145/225545.225547.
 
 
-The next example is [Ex2-SphericalGrids](./Ex2-SphericalGrids.ipynb)
+The next example is [Ex2-SphericalGrids](./Ex2-SphericalGrids.md)
 
 +++
 
@@ -135,4 +135,4 @@ triangulation         = stripy.cartesian_meshes.square_mesh(extent, spacingX, sp
 refined_triangulation = stripy.cartesian_meshes.square_mesh(extent, spacingX, spacingY, refinement_levels=3)
 ```
 
-This capability is shown in a companion notebook [Ex2-CartesianGrids](./Ex2-CartesianGrids.ipynb)
+This capability is shown in a companion notebook [Ex2-CartesianGrids](./Ex2-CartesianGrids.md)

--- a/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex2-CartesianGrids.md
+++ b/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex2-CartesianGrids.md
@@ -32,7 +32,7 @@ Any of the above meshes can be uniformly refined by specifying the `refinement_l
    - [Mesh characteristics](#Analysis-of-the-characteristics-of-the-triangulations)
    - [Compare the predefined meshes](#Plot-and-compare-the-predefined-meshes)
 
-The next example is [Ex3-Interpolation](./Ex3-Interpolation.ipynb)
+The next example is [Ex3-Interpolation](./Ex3-Interpolation.md)
 
 ---
 
@@ -177,4 +177,4 @@ mesh_fig(rand0, rand2, "Random" )
 
 
 
-The next example is [Ex3-Interpolation](./Ex3-Interpolation.ipynb)
+The next example is [Ex3-Interpolation](./Ex3-Interpolation.md)

--- a/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex3-Interpolation.md
+++ b/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex3-Interpolation.md
@@ -26,7 +26,7 @@ The next three examples demonstrate the interface to SRFPACK provided through `s
    - [Interpolate to a grid](#Interpolate-to-grid)
 
 
-The next example is [Ex4-Gradients](./Ex4-Gradients.ipynb)
+The next example is [Ex4-Gradients](./Ex4-Gradients.md)
 
 ---
 
@@ -205,4 +205,4 @@ fig.colorbar(im2, ax=ax2)
 plt.show()
 ```
 
-The next example is [Ex4-Gradients](./Ex4-Gradients.ipynb)
+The next example is [Ex4-Gradients](./Ex4-Gradients.md)

--- a/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex4-Gradients.md
+++ b/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex4-Gradients.md
@@ -21,7 +21,7 @@ SRFPACK is a Fortran 77 software package that constructs a smooth interpolatory 
    - [Evaluating accuracy](#Derivatives-of-solution-compared-to-analytic-values)
 
 
-The next example is [Ex5-Smoothing](./Ex5-Smoothing.ipynb)
+The next example is [Ex5-Smoothing](./Ex5-Smoothing.md)
 
 +++
 
@@ -263,7 +263,7 @@ ax[0,1].axis('off')
 plt.show()
 ```
 
-The next example is [Ex5-Smoothing](./Ex5-Smoothing.ipynb)
+The next example is [Ex5-Smoothing](./Ex5-Smoothing.md)
 
 ```{code-cell} ipython3
 dsdx, dsdy = mesh.gradient(analytic_sol)
@@ -287,4 +287,4 @@ ax[0,1].axis('off')
 plt.show()
 ```
 
-The next notebook is [Ex5-Smoothing](./Ex5-Smoothing.ipynb)
+The next notebook is [Ex5-Smoothing](./Ex5-Smoothing.md)

--- a/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex5-Smoothing.md
+++ b/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex5-Smoothing.md
@@ -25,7 +25,7 @@ Here we demonstrate how to access SRFPACK smoothing through the `stripy` interfa
    - [Results of smoothing](#Results-of-smoothing-with-different-value-of-sm)
    
 
-The next example is [Ex6-Scattered-Data](./Ex6-Scattered-Data.ipynb)
+The next example is [Ex6-Scattered-Data](./Ex6-Scattered-Data.md)
 
 +++
 
@@ -139,7 +139,7 @@ axis_mesh_field(fig, ax[1,1], mesh, stripy_smoothed3, label="smoothed3")
 plt.show()
 ```
 
-The next example is [Ex6-Scattered-Data](./Ex6-Scattered-Data.ipynb)
+The next example is [Ex6-Scattered-Data](./Ex6-Scattered-Data.md)
 
 ```{code-cell} ipython3
 fig, ax = plt.subplots(2,2, figsize=(12,10), facecolor="none")
@@ -152,4 +152,4 @@ axis_mesh_field(fig, ax[1,1], mesh, dds3[1], label="smoothed3")
 plt.show()
 ```
 
-The next notebook is [Ex6-Scattered-Data](./Ex6-Scattered-Data.ipynb)
+The next notebook is [Ex6-Scattered-Data](./Ex6-Scattered-Data.md)

--- a/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex6-Scattered-Data.md
+++ b/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex6-Scattered-Data.md
@@ -24,7 +24,7 @@ There are different ways to map point data to a smooth field. One way is to tria
    - [Distance weighting to vertices](#Inverse-distance-weighted-number-of-earthquakes)
    
    
-The next example is [Ex7-Refinement-of-Triangulations](./Ex7-Refinement-of-Triangulations.ipynb)
+The next example is [Ex7-Refinement-of-Triangulations](./Ex7-Refinement-of-Triangulations.md)
 
 +++
 
@@ -210,4 +210,4 @@ ax.gridlines(draw_labels=True)
 plt.show()
 ```
 
-The next example is [Ex7-Refinement-of-Triangulations](./Ex7-Refinement-of-Triangulations.ipynb)
+The next example is [Ex7-Refinement-of-Triangulations](./Ex7-Refinement-of-Triangulations.md)

--- a/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex8-Spline-Tension.md
+++ b/jupyterbook/SphericalMeshing/CartesianTriangulations/Ex8-Spline-Tension.md
@@ -145,4 +145,4 @@ axes_mesh_field(fig, axes[1,1], mesh, dy2, "y derivative spline tension")
 axes_mesh_field(fig, axes[1,2], mesh, dy1 - dy2, "x derivative difference")
 ```
 
-The next notebook is [Ex9-Voronoi-Diagram](Ex9-Voronoi-Diagram.ipynb)
+The next notebook is [Ex9-Voronoi-Diagram](Ex9-Voronoi-Diagram.md)

--- a/jupyterbook/SphericalMeshing/Litho1pt0/Ex2-Litho1Properties.md
+++ b/jupyterbook/SphericalMeshing/Litho1pt0/Ex2-Litho1Properties.md
@@ -173,6 +173,16 @@ def great_circle_Npoints(lonlat1, lonlat2, N):
 ```
 
 ```{code-cell} ipython3
+depths = np.linspace(-10.0, 250, 100)
+startlonlat=np.array([80.0,5.0])
+endlonlat  =np.array([80.0,45.0])
+
+midlonlat = 0.5 * ( startlonlat + endlonlat)
+
+lons, lats, d = great_circle_profile(startlonlat, endlonlat, depths, 2.5, "DENSITY")
+```
+
+```{code-cell} ipython3
 lonlat1r = np.radians(startlonlat)
 lonlat2r = np.radians(endlonlat)
 xyz1 = np.array(stripy.spherical.lonlat2xyz(lonlat1r[0], lonlat1r[1])).T
@@ -181,14 +191,6 @@ xyz2 = np.array(stripy.spherical.lonlat2xyz(lonlat2r[0], lonlat2r[1])).T
 N=100
 ratio = np.linspace(0.0,1.0, N).reshape(-1,1)
 mids = ratio * xyz2 + (1.0-ratio) * xyz1
-```
-
-```{code-cell} ipython3
-depths = np.linspace(-10.0, 250, 100)
-startlonlat=np.array([80.0,5.0])
-endlonlat  =np.array([80.0,45.0])
-
-lons, lats, d = great_circle_profile(startlonlat, endlonlat, depths, 2.5, "DENSITY")
 ```
 
 ```{code-cell} ipython3

--- a/jupyterbook/SphericalMeshing/Litho1pt0/Ex3-CrustalRegionalisation.md
+++ b/jupyterbook/SphericalMeshing/Litho1pt0/Ex3-CrustalRegionalisation.md
@@ -16,7 +16,6 @@ kernelspec:
 Crust 1.0 is built on a regular grid — it is also wrapped in the `litho1pt0` module
 
 ```{code-cell} ipython3
-import gdal
 import litho1pt0 as litho
 import numpy as np
 ```

--- a/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex1-Spherical-Triangulations.md
+++ b/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex1-Spherical-Triangulations.md
@@ -47,7 +47,7 @@ In this notebook we introduce the `sTriangulation` class itself.
    4. Renka, R. J. (1996), Algorithm 752; SRFPACK: software for scattered data fitting with a constrained surface under tension, ACM Transactions on Mathematical Software, 22(1), 9–17, doi:10.1145/225545.225547.
 
 
-The next example is [Ex2-SphericalGrids](./Ex2-SphericalGrids.ipynb)
+The next example is [Ex2-SphericalGrids](./Ex2-SphericalGrids.md)
 
 +++
 
@@ -237,7 +237,7 @@ spherical_triangulation         = stripy.spherical_meshes.icosahedral_mesh(refin
 refined_spherical_triangulation = stripy.spherical_meshes.icosahedral_mesh(refinement_levels=3)
 ```
 
-This capability is shown in a companion notebook [Ex2-SphericalGrids](./Ex2-SphericalGrids.ipynb)
+This capability is shown in a companion notebook [Ex2-SphericalGrids](./Ex2-SphericalGrids.md)
 
 ```{code-cell} ipython3
 :tags: [hide-cell]

--- a/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex2-SphericalGrids.md
+++ b/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex2-SphericalGrids.md
@@ -37,7 +37,7 @@ Any of the above meshes can be uniformly refined by specifying the `refinement_l
    - [Compare the predefined meshes](#Plot-and-compare-the-predefined-meshes)
 
 
-The next example is [Ex3-Interpolation](./Ex3-Interpolation.ipynb)
+The next example is [Ex3-Interpolation](./Ex3-Interpolation.md)
 
 ---
 
@@ -324,4 +324,4 @@ mesh_fig(rand0, rand2, "Random")
 
 ```
 
-The next example is [Ex3-Interpolation](./Ex3-Interpolation.ipynb)
+The next example is [Ex3-Interpolation](./Ex3-Interpolation.md)

--- a/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex3-Interpolation.md
+++ b/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex3-Interpolation.md
@@ -25,7 +25,7 @@ The next three examples demonstrate the interface to SSRFPACK provided through `
    - [Interpolation](#Interpolation-from-coarse-to-fine)
 
 
-The next example is [Ex4-Gradients](./Ex4-Gradients.ipynb)
+The next example is [Ex4-Gradients](./Ex4-Gradients.md)
 
 ---
 

--- a/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex4-Gradients.md
+++ b/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex4-Gradients.md
@@ -23,7 +23,7 @@ SSRFPACK is a Fortran 77 software package that constructs a smooth interpolatory
    - [Evaluating accuracy](#Derivatives-of-solution-compared-to-analytic-values)
 
 
-The next example is [Ex5-Smoothing](./Ex5-Smoothing.ipynb)
+The next example is [Ex5-Smoothing](./Ex5-Smoothing.md)
 
 +++
 
@@ -138,7 +138,7 @@ tris.control.List(options=["original", "ddlon", "ddlat", "ddlonerr", "ddlaterr"]
 lv.control.show()
 ```
 
-The next example is [Ex5-Smoothing](./Ex5-Smoothing.ipynb)
+The next example is [Ex5-Smoothing](./Ex5-Smoothing.md)
 
 ```{code-cell} ipython3
 vdisplay.stop()

--- a/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex5-Smoothing.md
+++ b/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex5-Smoothing.md
@@ -25,7 +25,7 @@ Here we demonstrate how to access SSRFPACK smoothing through the `stripy` interf
    - [Results of smoothing](#Results-of-smoothing-with-different-value-of-sm)
    
 
-The next example is [Ex6-Scattered-Data](./Ex6-Scattered-Data.ipynb)
+The next example is [Ex6-Scattered-Data](./Ex6-Scattered-Data.md)
 
 +++
 
@@ -211,7 +211,7 @@ tris.control.List(options=["original", "smoothed", "smoothed2", "smoothed3",
 lv.control.show()
 ```
 
-The next example is [Ex6-Scattered-Data](./Ex6-Scattered-Data.ipynb)
+The next example is [Ex6-Scattered-Data](./Ex6-Scattered-Data.md)
 
 ```{code-cell} ipython3
 

--- a/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex6-Scattered-Data.md
+++ b/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex6-Scattered-Data.md
@@ -25,7 +25,7 @@ There are different ways to map point data to a smooth field. One way is to tria
    - [Visualisation](#Visualisation)
    
    
-The next example is [Ex7-Refinement-of-Triangulations](./Ex7-Refinement-of-Triangulations.ipynb)
+The next example is [Ex7-Refinement-of-Triangulations](./Ex7-Refinement-of-Triangulations.md)
 
 +++
 
@@ -312,4 +312,4 @@ lv.control.show()
 vdisplay.stop()
 ```
 
-The next example is [Ex7-Refinement-of-Triangulations](./Ex7-Refinement-of-Triangulations.ipynb)
+The next example is [Ex7-Refinement-of-Triangulations](./Ex7-Refinement-of-Triangulations.md)

--- a/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex7-Refinement-of-Triangulations.md
+++ b/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex7-Refinement-of-Triangulations.md
@@ -422,4 +422,4 @@ print ("CBT", T.simplices.shape[0], equant.max(), equant.min(), size_ratio)
 
 ```
 
-The next example is [Ex8-Spline-Tension](./Ex8-Spline-Tension.ipynb)
+The next example is [Ex8-Spline-Tension](./Ex8-Spline-Tension.md)

--- a/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex8-Spline-Tension.md
+++ b/jupyterbook/SphericalMeshing/SphericalTriangulations/Ex8-Spline-Tension.md
@@ -207,7 +207,7 @@ tris.control.List(options=["original", "dlon", "dlat", "dlon_tension", "dlat_ten
 lv.control.show()
 ```
 
-The next notebook is [Ex9-Voronoi-Diagram](Ex9-Voronoi-Diagram.ipynb)
+The next notebook is [Ex9-Voronoi-Diagram](Ex9-Voronoi-Diagram.md)
 
 ```{code-cell} ipython3
 vdisplay.stop()

--- a/jupyterbook/_config.yml
+++ b/jupyterbook/_config.yml
@@ -22,12 +22,14 @@ sphinx:
 
 repository:
   url                       : "https://github.com/underworldcode/stripy"  # Online location of your book's source code
-  branch                    : "master"                                    # Which branch of the repository should be used when creating links (optional)
+  path_to_book              : "jupyterbook/"
+  branch                    : "dev"                                    # Which branch of the repository should be used when creating links (optional)
 
 launch_buttons:
   # jupyterhub_url: "https://phys3070.rses.geoscience.education"  # The URL for your JupyterHub. 
-  notebook_interface: "classic" # "jupyterlab" or "classic"
+  notebook_interface: "classic"           # "jupyterlab" or "classic"
   binderhub_url:  "https://mybinder.org"  # The URL of the BinderHub (e.g., https://mybinder.org)
+  thebe                     : true 
 
 execute:
   allow_errors : true # If `False`, when a code cell raises an error the execution is stopped, otherwise all cells are always run.

--- a/stripy/spherical.py
+++ b/stripy/spherical.py
@@ -310,7 +310,7 @@ class sTriangulation(object):
         Return the lon / lat components of the gradient
         of a scalar field on the surface of the UNIT sphere.
         (Note: the companion routine is derivatives_lonlat which returns
-        the components of the derivative in each direction - these differ by a factor of 
+        the components of the derivative in each direction - these differ by a factor of
         1/cos(lat) in the first component)
 
         The method consists of minimizing a quadratic functional Q(G) over
@@ -362,7 +362,7 @@ class sTriangulation(object):
         dlon = -dfxs * np.cos(lats) * np.sin(lons) + dfys * np.cos(lats) * np.cos(lons) # no z dependence
         dlat = -dfxs * np.sin(lats) * np.cos(lons) - dfys * np.sin(lats) * np.sin(lons) + dfzs * np.cos(lats)
 
-        corr = np.sqrt((1.0-z**2))  
+        corr = np.sqrt((1.0-z**2))
         valid = ~np.isclose(corr,0.0)
         dlon[valid] = dlon[valid] / corr[valid]
 
@@ -374,7 +374,7 @@ class sTriangulation(object):
         Return the lon / lat components of the derivatives
         of a scalar field on the surface of the UNIT sphere.
         (Note: the companion routine is gradient_lonlat which returns
-        the components of the surface gradient - these differ by a factor of 
+        the components of the surface gradient - these differ by a factor of
         1/cos(lat) in the first component)
 
 
@@ -748,7 +748,7 @@ F, FX, and FY are the values and partials of a linear function which minimizes Q
         zdata = self._shuffle_field(zdata)
         grad, iflgg = self._check_gradient(zdata, grad)
         sigma, iflgs = self._check_sigma(sigma)
-        
+
         nrow = len(lats)
 
 
@@ -1001,22 +1001,12 @@ F, FX, and FY are the values and partials of a linear function which minimizes Q
     def identify_vertex_neighbours(self, vertex):
         """
         Find the neighbour-vertices in the triangulation for the given vertex
-        (from the data structures of the triangulation)
+        (from the self.simplices array)
         """
-        vertex = self._permutation[vertex]
+        triangles = np.nonzero(self.simplices == vertex)[0]
+        vertex_and_neighbours = np.unique(np.concatenate(self.simplices[triangles]))
 
-        lpl = self.lend[vertex-1]
-        lp = lpl
-
-        neighbours = []
-
-        while True:
-            lp = self.lptr[lp-1]
-            neighbours.append(np.abs(self.lst[lp-1])-1)
-            if (lp == lpl):
-                break
-
-        return self._deshuffle_simplices(neighbours)
+        return vertex_and_neighbours[vertex_and_neighbours != vertex]
 
 
     def identify_vertex_triangles(self, vertices):


### PR DESCRIPTION
Correct apparent errors in the sTriangulation.identify_vertex_neighbours method by using the self.simplices array instead of the data structures of the triangulation.

The method as it currently exists has several errors. In particular, it can:

1. return the neighbors for the wrong vertex (indexed vertex - 1) and
2. return an incomplete list of those neighbors, as indicated by the self.simplices array. 

While this corrected method resolves these problems, it has the disadvantage that the neighboring vertices no longer appear as a counterclockwise-ordered sequence. Alas, I don't understand the data structures of the triangulation well enough to correct these errors while retaining the ordering.

My apologies for unwittingly committing revisions to delete trailing white space. While I think that's a fine improvement, I did not intend to mingle purposes and make those changes a part of this pull request.

```
# -*- coding: utf-8 -*-
"""
This test script:
 1. demonstrates that the existing sTriangulation.identify_vertex_neighbours method returns erroneous results, and
 2. demonstrates that a correction method returns the correct results in those same cases.
"""

import numpy as np
from stripy import spherical_meshes

mesh = spherical_meshes.random_mesh()

#%% Proposed correction method for sTriangulation.identify_vertex_neighbours
def identify_vertex_neighbours(self, vertex):
    """
    Find the neighbour-vertices in the triangulation for the given vertex
    (from the self.simplices array)

    This proposed revision uses the list of simplices to fix a couple of
    errors in the exist method. That method uses the data structures of
    the triangulation to return a counterclockwise-ordered sequence, but it
    (a) returns the neighbours for the wrong vertex (indexed vertex - 1) and
    (b) returns an incomplete list of those neighbours, as indicated by
    the self.simplices array.
    """
    triangles = np.nonzero(self.simplices == vertex)[0]
    vertex_and_neighbours = np.unique(np.concatenate(self.simplices[triangles]))

    return vertex_and_neighbours[vertex_and_neighbours != vertex]


def confirm_neighbours(mesh, vertex, vertex_neighbours):
    triangles_with_vertex = set(mesh.identify_vertex_triangles([vertex]))
    triangles_with_neighbours = set(mesh.identify_vertex_triangles(vertex_neighbours))
    return triangles_with_vertex < triangles_with_neighbours


#%% Test the existing method identify_vertex_neighbours
for vertex in range(mesh.npoints):
    vertex_neighbours = mesh.identify_vertex_neighbours(vertex)
    if not confirm_neighbours(mesh, vertex, vertex_neighbours):
        print('The method identified FALSE neighbours for vertex #{}!:'
              '\n\t{}'.format(vertex, vertex_neighbours))
        break
if vertex == mesh.npoints-1:
    print('The method identified only true neighbours for all vertices')


#%% Test the proposed correction method identify_vertex_neighbours
for vertex in range(mesh.npoints):
    vertex_neighbours = identify_vertex_neighbours(mesh, vertex)
    if not confirm_neighbours(mesh, vertex, vertex_neighbours):
        print('The proposed correction function identified FALSE neighbours for vertex #{}!:'
              '\n\t{}'.format(vertex, vertex_neighbours))
        break
if vertex == mesh.npoints-1:
    print('The proposed correction function identified only true neighbours for all vertices')
```
