### PR TITLE
Correct small errors in xyz2lonlat

### DIFF
--- a/stripy/spherical.py
+++ b/stripy/spherical.py
@@ -1597,7 +1597,7 @@ def xyz2lonlat(x,y,z):
     zs = np.array(z)
 
     lons = np.arctan2(ys, xs)
-    lats = np.arcsin(zs)
+    lats = np.arctan2(zs, np.hypot(ys, xs))
 
     return lons, lats
 
@@ -1613,7 +1613,7 @@ def dxyz2dlonlat(x,y,z, dfx, dfy, dfz):
     zs = np.array(z)
 
     lons = np.arctan2(ys, xs)
-    lats = np.arcsin(zs)
+    lats = np.arctan2(zs, np.hypot(ys, xs))
 
     dfxs = np.array(dfx)
     dfys = np.array(dfy)


### PR DESCRIPTION
Correct small errors near the poles in the `spherical.xyz2lonlat` and `spherical.dxyz2dlonlat` functions (and, by extension, in 5 methods of the `sTriangulation` class).

```
# -*- coding: utf-8 -*-
"""
This test script demonstrates that, near the North and South poles:
 1. the existing function spherical.xyz2lonlat is not quite the inverse of spherical.lonlat2xyz, and
 2. a corrected function xyz2lonlat is indeed the inverse of spherical.lonlat2xyz.
"""
import numpy as np
from stripy import spherical


#%% Proposed corrected function for spherical.xyz2lonlat
def xyz2lonlat(x,y,z):
    """
    Convert x,y,z representation of points *on the unit sphere* of the
    spherical triangulation to lon / lat (radians).

    Notes:
        no check is made here that (x,y,z) are unit vectors
    """

    xs = np.array(x)
    ys = np.array(y)
    zs = np.array(z)

    lons = np.arctan2(ys, xs)
    lats = np.arctan2(zs, np.hypot(ys, xs))

    return lons, lats


# Create coordinates for some points within 100m of the poles
lons = np.concatenate((np.linspace(-np.pi, np.pi, num=16),
                       np.linspace(-np.pi, np.pi, num=16)))
lats = np.ones_like(lons) * (1.0 - 1.0e-5)*np.pi/2
lats[lats.size//2:] *= -1
xs, ys, zs = spherical.lonlat2xyz(lons, lats)


#%% Confirm that, near the poles, the existing function spherical.xyz2lonlat
#   is not an accurate inverse of spherical.lonlat2xyz
lons_uncorrected, lats_uncorrected = spherical.xyz2lonlat(xs, ys, zs)
lats_uncorrected_errors = lats - lats_uncorrected
success = 'IS' if np.all(lats_uncorrected_errors == 0) else 'is NOT'
print('\nThe existing, uncorrected function xyz2lonlat\n\t'
      '{} the inverse of spherical.lonlat2xyz\n\terrors:{}'.format(success,lats_uncorrected_errors))


#%% Confirm that, near the poles, the corrected function xyz2lonlat is the
#   inverse of spherical.lonlat2xyz
lons_corrected, lats_corrected = xyz2lonlat(xs, ys, zs)
lats_corrected_errors = lats - lats_corrected
success = 'IS' if np.all(lats_corrected_errors == 0) else 'is NOT'
print('\nThe corrected function xyz2lonlat\n\t'
      '{} the inverse of spherical.lonlat2xyz\n\terrors:{}'.format(success,lats_corrected_errors))

```