### PR TITLE
Fix ci py versions and manylinux wheel path

### DIFF
--- a/.github/workflows/python_pip_build_test.yml
+++ b/.github/workflows/python_pip_build_test.yml
@@ -53,7 +53,7 @@ jobs:
             auto-update-conda: true
             environment-file: .github/workflows/resources/conda_test_environment.yml
             activate-environment: conda-test
-            python-version: 3.7
+            python-version: ${{ matrix.python-version }}
             use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
   
       - name: Install (self)

--- a/.github/workflows/python_pypi_upload_macos_wheel.yml
+++ b/.github/workflows/python_pypi_upload_macos_wheel.yml
@@ -47,7 +47,7 @@ jobs:
             auto-update-conda: true
             environment-file: .github/workflows/resources/conda_test_environment.yml
             activate-environment: conda-test
-            python-version: 3.7
+            python-version: ${{ matrix.python-version }}
             use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
   
       - name: Install (self)

--- a/.github/workflows/python_pypi_upload_mlinux_wheel.yml
+++ b/.github/workflows/python_pypi_upload_mlinux_wheel.yml
@@ -36,4 +36,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
  
       run: |
-        twine upload wheelhouse/*-manylinux*.whl --skip-existing
+        twine upload dist/*-manylinux*.whl --skip-existing

--- a/.github/workflows/python_pypi_upload_mlinux_wheel.yml
+++ b/.github/workflows/python_pypi_upload_mlinux_wheel.yml
@@ -21,9 +21,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
     
-
     - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.2.2-manylinux2010_x86_64
+      uses: RalfG/python-wheels-manylinux-build@v0.4.2-manylinux2014_x86_64
       with:
         python-versions: 'cp27-cp27m cp36-cp36m cp37-cp37m cp38-cp38 cp39-39'
         build-requirements: 'cython numpy scipy'


### PR DESCRIPTION
Upon the release of `v2.1.0` most of the wheels for different operating systems were not uploaded to [pypi](https://pypi.org/project/stripy/#files):

<img width="534" alt="CleanShot 2022-03-28 at 18 10 06@2x" src="https://user-images.githubusercontent.com/1504659/160512397-4ad96902-2ff8-4b37-9010-9e73798db77e.png">

This PR:

* Fixes the anaconda env python version which was hardcoded for macOS
* Fixes the path to the manylinux wheels created by https://github.com/RalfG/python-wheels-manylinux-build
* Updates to the latest version of https://github.com/RalfG/python-wheels-manylinux-build

Unfortunately GitHub actions do not yet have an Apple Silicon runner so we cannot compile M1 silicon wheels. 