### PR TITLE
Add multithreaded interpolation

### DIFF
--- a/src/srfpack.pyf
+++ b/src/srfpack.pyf
@@ -519,6 +519,7 @@ python module _srfpack ! in
             integer dimension(6*n-12), intent(in) :: lst,lptr
             integer dimension(n), intent(in) :: lend
             integer dimension(ns), intent(out) :: edata
+            threadsafe
         end subroutine interp_linear
         subroutine interp_cubic(n,ns,xs,ys,x,y,zdata,lst,lptr,lend,iflgs,sigma,iflgg,grad,odata,edata,ierr)
             integer, depend(x), intent(hide) :: n=len(x)
@@ -534,6 +535,7 @@ python module _srfpack ! in
             logical, intent(in) :: iflgg
             real dimension(2,n), intent(in) :: grad
             integer dimension(ns), intent(out) :: edata
+            threadsafe
         end subroutine interp_cubic
     end interface 
 end python module _srfpack

--- a/src/stripack.pyf
+++ b/src/stripack.pyf
@@ -272,6 +272,7 @@ python module _stripack ! in
             integer(kind=4) :: ist
             real(kind=8) :: pw
             integer(kind=4) :: ier
+            threadsafe
         end subroutine interp
 !        function arclen(p,q) ! in :_stripack:stripack.f90
 !            real(kind=8) dimension(3) :: p
@@ -419,7 +420,7 @@ python module _stripack ! in
             integer( kind = 4 ), intent(in), dimension(npts) :: lend
             integer( kind = 4 ), intent(in), dimension(6*npts-12) :: lst,lptr
             integer( kind = 4 ), intent(out), dimension(nptso) :: edata
-
+            threadsafe
 
         end subroutine interp_n
         subroutine trlist(n,list,lptr,lend,nrow,nt,ltri,ier) ! in :_stripack:stripack.f90

--- a/src/tripack.pyf
+++ b/src/tripack.pyf
@@ -217,6 +217,7 @@ python module _tripack ! in
             integer(kind=4) dimension(n), intent(in) :: lend
             real(kind=8), intent(out) :: dsq
             integer(kind=4), intent(out) :: nearnd
+            threadsafe
         end function nearnd
         subroutine nearnds(l,xp,yp,ist,n,x,y,list,lptr,lend,dsqs,ier) ! in :_tripack:tripack.f90
             integer(kind=4), depend(xp), intent(hide) :: l=len(xp)
@@ -229,6 +230,7 @@ python module _tripack ! in
             integer(kind=4) dimension(n), intent(in) :: lend
             real(kind=8) dimension(l), intent(out) :: dsqs
             integer(kind=4) dimension(l), intent(out) :: ier
+            threadsafe
         end subroutine nearnds
 !        subroutine optim(x,y,na,list,lptr,lend,nit,iwk,ier) ! in :_tripack:tripack.f90
 !            real(kind=8) dimension(*) :: x

--- a/stripy/cartesian.py
+++ b/stripy/cartesian.py
@@ -18,6 +18,8 @@ along with Stripy.  If not, see <http://www.gnu.org/licenses/>.
 
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+from multiprocessing import cpu_count
+
 from . import _tripack
 from . import _srfpack
 import numpy as np
@@ -634,7 +636,16 @@ class Triangulation(object):
         return ff.T
 
 
-    def interpolate(self, xi, yi, zdata, order=1, grad=None, sigma=None):
+    def interpolate(
+        self,
+        xi,
+        yi,
+        zdata,
+        order=1,
+        grad=None,
+        sigma=None,
+        threads=None,
+    ):
         """
         Base class to handle nearest neighbour, linear, and cubic interpolation.
         Given a triangulation of a set of nodes and values at the nodes,
@@ -660,6 +671,13 @@ class Triangulation(object):
                 `get_spline_tension_factors(zdata, tol=1e-3, grad=None)`
                 (only used in cubic interpolation)
 
+            threads : int, optional
+                Number of threads to use for interpolation.
+                The default value of `None` corresponds to
+                `multiprocessing.cpu_count()`.
+                Negative values count backwards, such that -1 is equivalent to
+                `multiprocessing.cpu_count()`, -2 to `cpu_count() - 1`, etc.
+
         Returns:
             zi : float / array of floats, shape (l,)
                 interpolates value(s) at (xi, yi)
@@ -668,63 +686,186 @@ class Triangulation(object):
         """
         shape = np.shape(xi)
 
+        if not isinstance(zdata, np.ndarray):
+            zdata = np.array(zdata)
         if zdata.size != self.npoints:
             raise ValueError('zdata should be same size as mesh')
 
-        if order == 0:
-            ierr = 0
-            ist = np.ones(shape, dtype=int)
-            zdata = self._shuffle_field(zdata)
-            ist, dist, zierr = _tripack.nearnds(xi, yi, ist, \
-                                                self._x, self._y, \
-                                                self.lst, self.lptr, self.lend)
-            zi = zdata[ist - 1]
+        if order not in {0, 1, 3}:
+            raise ValueError("order must be 0, 1, or 3")
+        if threads is None:
+            threads = cpu_count()
+        threads = int(threads)
+        if threads == 0:
+            raise ValueError("threads must not be zero")
+        if threads < 0:
+            threads = cpu_count() + threads + 1
 
-        elif order == 1:
-            zdata = self._shuffle_field(zdata)
-            zi, zierr, ierr = _srfpack.interp_linear(xi, yi,\
-                                                self._x,self._y, zdata, \
-                                                self.lst, self.lptr, self.lend)
-        elif order == 3:
+        if order == 3:
             sigma, iflgs = self._check_sigma(sigma)
             grad, iflgg = self._check_gradient(zdata, grad)
-            zdata = self._shuffle_field(zdata)
-
-            zi, zierr, ierr = _srfpack.interp_cubic(xi, yi, \
-                                                    self._x, self._y, zdata, \
-                                                    self.lst,self.lptr,self.lend,\
-                                                    iflgs, sigma, iflgg, grad)
         else:
-            raise ValueError("order must be 0, 1, or 3")
+            iflgs = None
+            iflgg = None
+        zdata = self._shuffle_field(zdata)
+
+        if threads == 1:
+            if order == 0:
+                ierr = 0
+                ist = np.ones(shape, dtype=int)
+                ist, dist, zierr = _tripack.nearnds(
+                    xi, yi, ist,
+                    self._x, self._y,
+                    self.lst, self.lptr, self.lend)
+                zi = zdata[ist - 1]
+            elif order == 1:
+                zi, zierr, ierr = _srfpack.interp_linear(
+                    xi, yi,
+                    self._x,self._y, zdata,
+                    self.lst, self.lptr, self.lend)
+            else:  # order == 3
+                zi, zierr, ierr = _srfpack.interp_cubic(
+                    xi, yi,
+                    self._x, self._y, zdata,
+                    self.lst,self.lptr,self.lend,
+                    iflgs, sigma, iflgg, grad)
+
+        else:
+            # The following code is largely adapted from here:
+            # https://numpy.org/doc/stable/reference/random/multithreading.html
+            import concurrent.futures
+
+            size = np.size(xi)
+            zi = np.full(size, np.nan)
+            zierr = np.full(size, np.nan)
+            ierr = np.zeros(threads)
+            step = np.ceil(size / threads).astype(np.int_)
+            futures = {}
+            executor = concurrent.futures.ThreadPoolExecutor(threads)
+
+            def _f(
+                order,
+                out_zi,
+                out_zierr,
+                out_ierr,
+                xi,
+                yi,
+                x,
+                y,
+                zdata,
+                lst,
+                lptr,
+                lend,
+                iflgs,
+                sigma,
+                iflgg,
+                grad,
+                first,
+                last,
+                ierr_index,
+            ):
+                if order == 0:
+                    ierr = 0
+                    ist = np.ones(np.shape(xi), dtype=int)
+                    ist, dist, zierr = _tripack.nearnds(
+                        xi[first:last], yi[first:last], ist,
+                        x, y, lst, lptr, lend,
+                    )
+                    zi = zdata[ist - 1]
+                elif order == 1:
+                    zi, zierr, ierr = _srfpack.interp_linear(
+                        xi[first:last], yi[first:last],
+                        x, y, zdata,
+                        lst, lptr, lend,
+                    )
+                else:
+                    zi, zierr, ierr = _srfpack.interp_cubic(
+                        xi[first:last], yi[first:last],
+                        x, y, zdata,
+                        lst, lptr, lend,
+                        iflgs, sigma, iflgg, grad,
+                    )
+
+                out_zi[first:last] = zi
+                out_zierr[first:last] = zierr
+                out_ierr[ierr_index] = ierr
+
+            for i in range(threads):
+                first = i * step
+                last = (i + 1) * step
+                args = (
+                    _f,
+                    order,
+                    zi,
+                    zierr,
+                    ierr,
+                    xi,
+                    yi,
+                    self._x,
+                    self._y,
+                    zdata,
+                    self.lst,
+                    self.lptr,
+                    self.lend,
+                    iflgs,
+                    sigma,
+                    iflgg,
+                    grad,
+                    first,
+                    last,
+                    i,
+                )
+                futures[executor.submit(*args)] = i
+            concurrent.futures.wait(futures)
+            executor.shutdown(False)
+            ierr = int((ierr != 0).any())
 
         if ierr != 0:
             import warnings
-            warnings.warn('Warning some points may have errors - check error array\n'.format(ierr))
+            warnings.warn(
+                'Warning some points may have errors - check error array'
+            )
             zi[zierr < 0] = np.nan
 
         return zi.reshape(shape), zierr.reshape(shape)
 
 
-    def interpolate_nearest(self, xi, yi, zdata):
+    def interpolate_nearest(self, xi, yi, zdata, threads=None):
         """
         Interpolate using nearest-neighbour approximation
         Returns the same as `interpolate(xi,yi,zdata,order=0)`
         """
-        return self.interpolate(xi, yi, zdata, order=0)
+        return self.interpolate(xi, yi, zdata, order=0, threads=threads)
 
-    def interpolate_linear(self, xi, yi, zdata):
+    def interpolate_linear(self, xi, yi, zdata, threads=None):
         """
         Interpolate using linear approximation
         Returns the same as `interpolate(xi,yi,zdata,order=1)`
         """
-        return self.interpolate(xi, yi, zdata, order=1)
+        return self.interpolate(xi, yi, zdata, order=1, threads=threads)
 
-    def interpolate_cubic(self, xi, yi, zdata, grad=None, sigma=None):
+    def interpolate_cubic(
+        self,
+        xi,
+        yi,
+        zdata,
+        grad=None,
+        sigma=None,
+        threads=None,
+    ):
         """
         Interpolate using cubic spline approximation
         Returns the same as `interpolate(xi,yi,zdata,order=3,sigma=sigma)`
         """
-        return self.interpolate(xi, yi, zdata, order=3, grad=grad, sigma=sigma)
+        return self.interpolate(
+            xi,
+            yi,
+            zdata,
+            order=3,
+            grad=grad,
+            sigma=sigma,
+            threads=threads,
+        )
 
 
     def neighbour_simplices(self):


### PR DESCRIPTION
Add `threads` argument to `interpolate` methods for `Triangulation` and `sTriangulation` classes. Multithreading currently does not seem to work for spherical cubic interpolation (potentially a memory requirement issue?) so it is not supported and will report a warning.

The performance improvement achieved by using different numbers of threads can be shown using the attached script: [test_nthreads.py.zip](https://github.com/underworldcode/stripy/files/10150842/test_nthreads.py.zip). 

![output_nthreads](https://user-images.githubusercontent.com/60722740/205559559-de66db6b-4508-46f3-83eb-010d88f05f6b.png)
